### PR TITLE
Handling multiple inserts

### DIFF
--- a/src/main/javacc/ZqlJJParser.jj
+++ b/src/main/javacc/ZqlJJParser.jj
@@ -391,7 +391,7 @@ ZInsert InsertStatement():
   "INSERT" "INTO" s = TableReference() { ins = new ZInsert(s); }
    ["(" s = TableColumn() { v = new ArrayList(); v.add(s); }
     ("," s = TableColumn() { v.add(s); } )* ")" { ins.addColumns(v); } ]
-   ( "VALUES" "(" v = SQLExpressionList() ")"
+   ( "VALUES" "(" v = SQLExpressionList() ")" ( "," "(" v = SQLExpressionList() ")" )*
      { ZExpression e = new ZExpression(",");
        e.setOperands(v); ins.addValueSpec(e); }
      |

--- a/src/main/javacc/ZqlJJParser.jj
+++ b/src/main/javacc/ZqlJJParser.jj
@@ -391,7 +391,7 @@ ZInsert InsertStatement():
   "INSERT" "INTO" s = TableReference() { ins = new ZInsert(s); }
    ["(" s = TableColumn() { v = new ArrayList(); v.add(s); }
     ("," s = TableColumn() { v.add(s); } )* ")" { ins.addColumns(v); } ]
-   ( "VALUES" "(" v = SQLExpressionList() ")" ( "," "(" v = SQLExpressionList() ")" )*
+   ( "VALUES" v = ZInsertValuePair()
      { ZExpression e = new ZExpression(",");
        e.setOperands(v); ins.addValueSpec(e); }
      |
@@ -807,9 +807,21 @@ List SQLExpressionList():
   ZExp e;
 }
 {
-    e = SQLSimpleExpressionOrPreparedCol() { v.add(e); }
+    ("(" e = SQLSimpleExpressionOrPreparedCol() { v.add(e); } )
     ("," e = SQLSimpleExpressionOrPreparedCol() { v.add(e); } )*
+    (")")
     { return v; }
+}
+
+List ZInsertValuePair():
+{
+  List valuePair = new ArrayList();
+  List e;
+}
+{
+    e = SQLExpressionList() { valuePair.add(e); }
+    ("," e = SQLExpressionList() { valuePair.add(e); } )*
+    { return valuePair; }
 }
 
 ZExpression SQLRelationalOperatorExpression():


### PR DESCRIPTION
This PR tries to handle multiple rows on an INSERT statement by letting `ZInsertValuePair` to handle the matching of one or more SQLExpressionList and therefore fixing issue #10 . Note that tests recently introduced are broken, but not because of anything I added here. Discussions are welcome.
